### PR TITLE
add entrypoint to builder

### DIFF
--- a/src/Dockerfile.fs
+++ b/src/Dockerfile.fs
@@ -251,8 +251,8 @@ module Builders =
             let instruction = Dockerfile.Cmd(Dockerfile.ShellCommand shellCmd)
             { config with Instructions = config.Instructions @ [ instruction ] }
         [<CustomOperation "entrypoint">]
-        member _.Entrypoint(config: DockerfileSpec, shellCmd: string) =
-            let instruction = Dockerfile.Entrypoint(Dockerfile.ShellCommand shellCmd)
+        member _.Entrypoint(config: DockerfileSpec,  exec:string, args:string list) =
+            let instruction = Dockerfile.Entrypoint(Dockerfile.Exec (exec, args))
             { config with Instructions = config.Instructions @ [ instruction ] }
         [<CustomOperation "copy">]
         member _.Copy (config:DockerfileSpec, source:string, dest:string) =

--- a/src/Dockerfile.fs
+++ b/src/Dockerfile.fs
@@ -250,6 +250,10 @@ module Builders =
         member _.CmdShellCommand (config:DockerfileSpec, shellCmd:string) =
             let instruction = Dockerfile.Cmd(Dockerfile.ShellCommand shellCmd)
             { config with Instructions = config.Instructions @ [ instruction ] }
+        [<CustomOperation "entrypoint">]
+        member _.Entrypoint(config: DockerfileSpec, shellCmd: string) =
+            let instruction = Dockerfile.Entrypoint(Dockerfile.ShellCommand shellCmd)
+            { config with Instructions = config.Instructions @ [ instruction ] }
         [<CustomOperation "copy">]
         member _.Copy (config:DockerfileSpec, source:string, dest:string) =
             let instruction = Dockerfile.Copy(Dockerfile.SingleSource source, dest, None)

--- a/tests/BuilderTests.fs
+++ b/tests/BuilderTests.fs
@@ -15,7 +15,8 @@ let ``Simple builder`` () =
         from "mcr.microsoft.com/dotnet/runtime:5.0.8"
         expose 80
         copy_from "builder" "/path/to/source/myApp.dll" "/path/to/dest"
-        cmd "dotnet /path/to/dest/myApp.dll"
+        entrypoint "dotnet"
+        cmd "/path/to/dest/myApp.dll"
     }
     let spec = myDockerfile.Build ()
     let expected = """
@@ -27,7 +28,8 @@ RUN dotnet build -c Release -o app
 FROM mcr.microsoft.com/dotnet/runtime:5.0.8
 EXPOSE 80
 COPY --from=builder /path/to/source/myApp.dll /path/to/dest
-CMD dotnet /path/to/dest/myApp.dll
+ENTRYPOINT dotnet
+CMD /path/to/dest/myApp.dll
 """
     Assert.Equal (expected.Trim(), spec)
 

--- a/tests/BuilderTests.fs
+++ b/tests/BuilderTests.fs
@@ -15,7 +15,7 @@ let ``Simple builder`` () =
         from "mcr.microsoft.com/dotnet/runtime:5.0.8"
         expose 80
         copy_from "builder" "/path/to/source/myApp.dll" "/path/to/dest"
-        entrypoint "dotnet"
+        entrypoint "dotnet" []
         cmd "/path/to/dest/myApp.dll"
     }
     let spec = myDockerfile.Build ()
@@ -28,7 +28,7 @@ RUN dotnet build -c Release -o app
 FROM mcr.microsoft.com/dotnet/runtime:5.0.8
 EXPOSE 80
 COPY --from=builder /path/to/source/myApp.dll /path/to/dest
-ENTRYPOINT dotnet
+ENTRYPOINT ["dotnet"]
 CMD /path/to/dest/myApp.dll
 """
     Assert.Equal (expected.Trim(), spec)


### PR DESCRIPTION
Entrypoint is missing from the CE builder. This adds the exec form to abide by this recomendation https://docs.docker.com/reference/build-checks/json-args-recommended/